### PR TITLE
Rearrange Spain, use more local names, don't get Poland subdivisions

### DIFF
--- a/src/data/countries.json
+++ b/src/data/countries.json
@@ -9,7 +9,7 @@
         "countryCode": "BE",
         "locale": "en"
     },
-    "Germany": {
+    "Deutschland": {
         "name": "Deutschland",
         "divisions": {
             "Baden-Württemberg": 62611,
@@ -32,6 +32,33 @@
         "countryCode": "DE",
         "locale": "de-DE",
         "subdivisionAdminLevel": 5
+    },
+    "España": {
+        "name": "España",
+        "divisions": {
+            "Andalucía": 349044,
+            "Aragón": 349045,
+            "Asturias": 349033,
+            "Islas Baleares": 348981,
+            "Islas Canarias": 349048,
+            "Cantabria": 349013,
+            "Castilla-La Mancha": 349052,
+            "Castilla y León": 349041,
+            "Cataluña": 349053,
+            "Comunidad Valenciana": 349043,
+            "Extremadura": 349050,
+            "Galicia": 349036,
+            "La Rioja": 348991,
+            "Comunidad de Madrid": 349055,
+            "Región de Murcia": 349047,
+            "Comunidad Foral de Navarra": 349027,
+            "País Vasco": 349042,
+            "Ceuta": 1154756,
+            "Melilla": 1154757
+        },
+        "countryCode": "ES",
+        "locale": "es-ES",
+        "subdivisionAdminLevel": 6
     },
     "France": {
         "name": "France",
@@ -118,7 +145,7 @@
         "countryCode": "NL",
         "locale": "nl-NL"
     },
-    "Poland": {
+    "Polska": {
         "name": "Polska",
         "divisions": {
             "województwo dolnośląskie": 224457,
@@ -139,8 +166,7 @@
             "województwo zachodniopomorskie": 104401
         },
         "countryCode": "PL",
-        "locale": "en",
-        "subdivisionAdminLevel": 6
+        "locale": "en"
     },
     "South Africa": {
         "name": "South Africa",
@@ -190,33 +216,6 @@
         },
         "countryCode": "CH",
         "locale": "en"
-    },
-    "Spain": {
-        "name": "España",
-        "divisions": {
-            "Andalucía": 349044,
-            "Aragón": 349045,
-            "Asturias": 349033,
-            "Islas Baleares": 348981,
-            "Islas Canarias": 349048,
-            "Cantabria": 349013,
-            "Castilla-La Mancha": 349052,
-            "Castilla y León": 349041,
-            "Cataluña": 349053,
-            "Comunidad Valenciana": 349043,
-            "Extremadura": 349050,
-            "Galicia": 349036,
-            "La Rioja": 348991,
-            "Comunidad de Madrid": 349055,
-            "Región de Murcia": 349047,
-            "Comunidad Foral de Navarra": 349027,
-            "País Vasco": 349042,
-            "Ceuta": 1154756,
-            "Melilla": 1154757
-        },
-        "countryCode": "ES",
-        "locale": "es-ES",
-        "subdivisionAdminLevel": 6
     },
     "United Kingdom": {
         "name": "United Kingdom",


### PR DESCRIPTION
Fetching the all the subdivisions from Poland was taking too long. Now that there is pagination, the report pages can be manageable even with large numbers of invalid phone numbers.

Ref #5

