### PR TITLE
Save which elements have been clicked

### DIFF
--- a/src/html-report.js
+++ b/src/html-report.js
@@ -335,6 +335,7 @@ async function generateHtmlReport(countryName, subdivisionStats, invalidNumbers,
         const DEFAULT_EDITORS_DESKTOP = ${JSON.stringify(DEFAULT_EDITORS_DESKTOP)};
         const DEFAULT_EDITORS_MOBILE = ${JSON.stringify(DEFAULT_EDITORS_MOBILE)};
         const DATA_FILE_PATH = './${subdivisionStats.slug}.json';
+        const DATA_LAST_UPDATED = '${subdivisionStats.lastUpdated}';
         const STORAGE_KEY = 'osm_report_editors';
         ${clientOsmEditorsScript}
         for (const editorId in OSM_EDITORS) {

--- a/src/input.css
+++ b/src/input.css
@@ -105,6 +105,10 @@
   @apply bg-green-500 text-white hover:bg-green-600 dark:bg-green-700 dark:hover:bg-green-600 dark:text-gray-200;
 }
 
+@utility btn-clicked {
+  @apply bg-gray-300 text-gray-500 hover:bg-gray-400 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 cursor-pointer;
+}
+
 @utility label {
   @apply text-xs font-semibold inline-flex items-center px-2 py-1 rounded-full text-center;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -127,7 +127,8 @@ async function processSubdivision(subdivision, countryData, rawDivisionName, loc
         slug: safeName(subdivision.name),
         invalidCount: invalidNumbers.length,
         autoFixableCount: autoFixableCount,
-        totalNumbers: totalNumbers
+        totalNumbers: totalNumbers,
+        lastUpdated: new Date().toISOString()
     };
 
     const countryDir = path.join(PUBLIC_DIR, safeName(countryName));


### PR DESCRIPTION
When an edit or fix button is clicked, the id of the element is saved to local storage, keyed by the timestamp of the page creation.

All buttons are made grey when an item has been clicked, and this persists on refresh or navigation away and back.

When data is refreshed, the state of the buttons is refreshed, so if a button was clicked on a previous version (day) of the page, it will not show as greyed out on a new version of the page.