### PR TITLE
Minify json files on write, don't reminify them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,15 +106,6 @@ jobs:
           done
         shell: bash
 
-      - name: Run JSON Minifier
-        if: env.BUILD_TYPE == 'full'
-        run: |
-          find public -name "*.json" | while read -r file; do
-            npx node-minify --compressor jsonminify --input "$file" --output "$file.min"
-            mv "$file.min" "$file"
-          done
-        shell: bash
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/src/history-processor.js
+++ b/src/history-processor.js
@@ -115,7 +115,7 @@ function processHistory() {
         const outputDir = path.join(PUBLIC_DIR, countrySlug);
         const outputPath = path.join(outputDir, 'history-data.json');
         fs.mkdirSync(outputDir, { recursive: true });
-        fs.writeFileSync(outputPath, JSON.stringify(aggregatedCountryData, null, 2));
+        fs.writeFileSync(outputPath, JSON.stringify(aggregatedCountryData, null));
 
         console.log(`History data for ${countrySlug} processed and saved to ${outputPath}`);
     }
@@ -130,7 +130,7 @@ function processHistory() {
     aggregatedData.overall = overallArray;
 
     const outputPath = path.join(PUBLIC_DIR, 'history-data.json');
-    fs.writeFileSync(outputPath, JSON.stringify(aggregatedData, null, 2));
+    fs.writeFileSync(outputPath, JSON.stringify(aggregatedData, null));
 
     console.log(`History data processed and saved to ${outputPath}`);
 }


### PR DESCRIPTION
With the new process to store invalid items in a json file per subdivision, the node json minifier was taking a long time. Those files were being written minified anyway, so now just minify the history files and remove the json minifier step from build.