### PR TITLE
Fix MISSING_KEY:timeAgoJustNow in country page

### DIFF
--- a/src/html-country.js
+++ b/src/html-country.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { Eta } = require('eta');
 const { minify } = require('html-minifier-terser');
 const { PUBLIC_DIR, NAMES_BUILD_DIR, GITHUB_LINK, IS_TEST_MODE, MINIFY_OPTIONS } = require('./constants');
-const { translate } = require('./i18n');
+const { translate, getTranslations } = require('./i18n');
 const { createStatsBox, escapeHTML, getFooterData, getIconAttributionHtml} = require('./html-utils');
 const { safeName } = require('./data-processor');
 
@@ -31,6 +31,7 @@ async function generateCountryIndexHtml(reportType, countryData) {
         translate,
         getIconAttributionHtml,
         GITHUB_LINK,
+        translations: getTranslations(locale),
     };
 
     const htmlContent = eta.render("country", templateData);

--- a/test/html-country.test.js
+++ b/test/html-country.test.js
@@ -32,6 +32,12 @@ jest.mock('../src/i18n', () => ({
         if (key === 'osmPhoneNumberValidation' && locale === 'nl-NL') return 'OSM Telefoon&shy;nummer&shy;validatie';
         return key;
     },
+    getTranslations: (locale) => {
+        return {
+            exampleKey: 'Example Translation',
+            currentLocale: locale,
+        };
+    },
 }));
 
 describe('generateCountryIndexHtml', () => {


### PR DESCRIPTION
Noticed `MISSING_KEY:timeAgoJustNow` at https://confusedbuffalo.github.io/phone-report/polska/
<img width="670" height="110" alt="image" src="https://github.com/user-attachments/assets/01e5c8f1-099f-4095-94da-631e57a827e4" />

---

Fix tested locally.
Before:
<img width="689" height="121" alt="image" src="https://github.com/user-attachments/assets/2be7c96e-4b45-44ec-8ec8-76f90faef776" />
After:
<img width="707" height="113" alt="image" src="https://github.com/user-attachments/assets/b354d1fd-0dc3-4477-b46c-7e540088fc62" />
