### PR TITLE
fix: Reconsider toll free formatting

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -407,6 +407,15 @@ export const CAN_ADD_COUNTRY_CODE_TO_INCORRECT_LEADING_PLUS = [
 ];
 export const INCORRECT_PLUS_CAN_START_WITH_COUNTRY_CODE = ['BL', 'GF', 'GP', 'MF', 'MQ', 'RE', 'YT'];
 
+export const FORCE_TOLL_FREE_AS_NATIONAL_COUNTRIES = [
+    'DE', // https://community.openstreetmap.org/t/telefonnummer-nebenstelle-kennzeichnen-phonenumbervalidator/137711/19
+    'FR', // https://github.com/confusedbuffalo/phone-report/issues/18
+    'IE', // https://community.openstreetmap.org/t/validating-phone-numbers-in-ireland/143173/4
+    'IT', // https://github.com/confusedbuffalo/phone-report/issues/217
+    'NL', // https://github.com/confusedbuffalo/phone-report/issues/315
+    'NZ', // https://community.openstreetmap.org/t/nz-check-and-fix-nz-phone-numbers/143168/4
+];
+
 export const TOLL_FREE_AS_INTERNATIONAL_COUNTRIES = [...NANP_COUNTRY_CODES];
 
 export const COUNTRIES_WITH_PHONEWORDS = [...NANP_COUNTRY_CODES, 'AU', 'NZ', 'SG'];

--- a/src/phone-processor.js
+++ b/src/phone-processor.js
@@ -12,6 +12,7 @@ import {
     PHONE_TAG_PREFERENCE_ORDER,
     NANP_COUNTRY_CODES,
     ACCEPTABLE_EXTENSION_FORMATS,
+    FORCE_TOLL_FREE_AS_NATIONAL_COUNTRIES,
     ALL_NUMBER_TAGS,
     FAX_TAGS,
     NON_STANDARD_COST_TYPES,
@@ -321,12 +322,12 @@ export function getNumberAndExtension(numberStr, countryCode) {
  * Formats a single phone number to the appropriate national standard
  * @param {PhoneNumber} phoneNumber - The phone number object
  * @param {string} countryCode - The country code for formatting.
+ * @param {boolean} tollFreeAsInternational - Whether or not toll free numbers should be formatted with a country code.
  * @returns {string} The formatted number
  */
-function getFormattedNumber(phoneNumber) {
+function getFormattedNumber(phoneNumber, tollFreeAsInternational = false) {
     const countryCode = phoneNumber.country;
     const originalExt = phoneNumber.ext;
-    const tollFreeAsInternational = TOLL_FREE_AS_INTERNATIONAL_COUNTRIES.includes(countryCode);
 
     // Temporarily clear the extension to get the core number without libphonenumber's formatting
     if (originalExt) {
@@ -600,7 +601,12 @@ export function processSingleNumber(numberStr, countryCode, osmTags = {}, tag) {
         }
 
         if (phoneNumber) {
-            suggestedFix = getFormattedNumber(phoneNumber);
+            const tollFreeAsInternational = TOLL_FREE_AS_INTERNATIONAL_COUNTRIES.includes(countryCode)
+                ? true
+                : FORCE_TOLL_FREE_AS_NATIONAL_COUNTRIES.includes(countryCode)
+                  ? false
+                  : numberStr.includes('+') || numberStr.startsWith('00');
+            suggestedFix = getFormattedNumber(phoneNumber, tollFreeAsInternational);
         }
 
         if (phoneNumber && phoneNumber.isValid()) {
@@ -1037,6 +1043,10 @@ export async function validateNumbers(elementStream, countryCode, tmpFilePath) {
 
             const allNormalisedNumbers = FAX_TAGS.includes(tag) ? allNormalisedFaxNumbers : allNormalisedPhoneNumbers;
 
+            const tollFreeAsInternational =
+                TOLL_FREE_AS_INTERNATIONAL_COUNTRIES.includes(baseCountryCode) ||
+                !FORCE_TOLL_FREE_AS_NATIONAL_COUNTRIES.includes(baseCountryCode);
+
             // --- Detect internal duplicates within the same tag ---
             const formattedNumbers = validatedNumbers.map(n => n.format('INTERNATIONAL'));
             const uniqueFormattedSet = [...new Set(formattedNumbers)];
@@ -1045,7 +1055,7 @@ export async function validateNumbers(elementStream, countryCode, tmpFilePath) {
                 hasInternalDuplicate = true;
                 suggestedFix = uniqueFormattedSet
                     .map(number => {
-                        return getFormattedNumber(parsePhoneNumber(number, baseCountryCode));
+                        return getFormattedNumber(parsePhoneNumber(number, baseCountryCode), tollFreeAsInternational);
                     })
                     .join('; ');
             }
@@ -1057,7 +1067,10 @@ export async function validateNumbers(elementStream, countryCode, tmpFilePath) {
                 // Skip duplicate detection for whatsapp numbers
                 if (tag === 'contact:whatsapp') continue;
 
-                const normalisedNumber = getFormattedNumber(phoneNumber).replace(getSpacingRegex(baseCountryCode), '');
+                const normalisedNumber = getFormattedNumber(phoneNumber, tollFreeAsInternational).replace(
+                    getSpacingRegex(baseCountryCode),
+                    ''
+                );
 
                 // Correct the tag of a mismatch type number early
                 const normalisedMismatch = validationResult.mismatchTypeNumbers.map(number =>
@@ -1115,7 +1128,10 @@ export async function validateNumbers(elementStream, countryCode, tmpFilePath) {
                         const uniqueFormattedKeptSet = [...new Set(formattedKeptNumbers)];
                         const validatedKeptValue = uniqueFormattedKeptSet
                             .map(number => {
-                                return getFormattedNumber(parsePhoneNumber(number, baseCountryCode));
+                                return getFormattedNumber(
+                                    parsePhoneNumber(number, baseCountryCode),
+                                    tollFreeAsInternational
+                                );
                             })
                             .join('; ');
 

--- a/test/phone-processor.test.js
+++ b/test/phone-processor.test.js
@@ -767,11 +767,9 @@ describe('processSingleNumber', () => {
         expect(result.isInvalid).toBe(false);
     });
 
-    test('GB: toll free phone number with country code is invalid', () => {
+    test('GB: toll free phone number with country code is valid', () => {
         const result = processSingleNumber('+44 800 00 1234', SAMPLE_COUNTRY_CODE_GB);
-        expect(result.isInvalid).toBe(true);
-        expect(result.autoFixable).toBe(true);
-        expect(result.suggestedFix).toEqual('0800 001234');
+        expect(result.isInvalid).toBe(false);
     });
 
     test('GB: toll free phone number with dashes is fixable to national format', () => {
@@ -781,18 +779,18 @@ describe('processSingleNumber', () => {
         expect(result.suggestedFix).toBe('0800 001234');
     });
 
-    test('GB: toll free phone number with country code and invalid formatting is fixable to national format', () => {
+    test('GB: toll free phone number with country code and invalid formatting is fixable to international format', () => {
         const result = processSingleNumber('(+44) 0800 00 1234', SAMPLE_COUNTRY_CODE_GB);
         expect(result.isInvalid).toBe(true);
         expect(result.autoFixable).toBe(true);
-        expect(result.suggestedFix).toBe('0800 001234');
+        expect(result.suggestedFix).toBe('+44 800 001234');
     });
 
-    test('GB: toll free phone number with 00 and country code is fixable to national format', () => {
+    test('GB: toll free phone number with 00 and country code is fixable to international format', () => {
         const result = processSingleNumber('0044 0800 00 1234', SAMPLE_COUNTRY_CODE_GB);
         expect(result.isInvalid).toBe(true);
         expect(result.autoFixable).toBe(true);
-        expect(result.suggestedFix).toBe('0800 001234');
+        expect(result.suggestedFix).toBe('+44 800 001234');
     });
 
     test('GB: a number with tabs is invalid but fixable', () => {
@@ -1085,14 +1083,14 @@ describe('processSingleNumber', () => {
         expect(result.suggestedFix).toEqual('0800 1234567');
     });
 
-    test('DE: toll free number in international format is invalid', () => {
+    test('DE: toll free number already in international format is invalid and fixable to national format', () => {
         const result = processSingleNumber('+49 800 1234 567', SAMPLE_COUNTRY_CODE_DE);
         expect(result.isInvalid).toBe(true);
         expect(result.autoFixable).toBe(true);
         expect(result.suggestedFix).toEqual('0800 1234567');
     });
 
-    test('AT: toll free number is valid', () => {
+    test('AT: toll free number is valid and fixable to national format', () => {
         const result = processSingleNumber('800 8481 0000', 'AT');
         expect(result.isInvalid).toBe(true);
         expect(result.autoFixable).toBe(true);
@@ -1105,7 +1103,7 @@ describe('processSingleNumber', () => {
         expect(result.isInvalid).toBe(false);
     });
 
-    test('FR: shared cost number in international format is invalid', () => {
+    test('FR: shared cost number in international format is invalid and fixable to national format', () => {
         const result = processSingleNumber('+33 820 39 39 00', SAMPLE_COUNTRY_CODE_FR);
         expect(result.isInvalid).toBe(true);
         expect(result.autoFixable).toBe(true);
@@ -1626,7 +1624,7 @@ describe('validateNumbers', () => {
     const VALID_MOBILE_2 = '+44 7712 900001';
     const FIXABLE_MOBILE_INPUT = '07712  900000';
     const FIXABLE_MOBILE_SUGGESTED_FIX = '+44 7712 900000';
-    const VALID_TOLL_FREE = '0800 001234';
+    const VALID_TOLL_FREE = '+44 800 001234';
 
     // DE numbers
     const SLASH_IN_NUMBER_DE = '+498131/275715';
@@ -1673,6 +1671,28 @@ describe('validateNumbers', () => {
         });
         expect(invalidItem.suggestedFixes).toEqual({
             'contact:phone': FIXABLE_LANDLINE_SUGGESTED_FIX,
+        });
+    });
+
+    test('AT: should identify a single fixable invalid toll free number (no country code) and provide suggested fix', async () => {
+        const elements = [createGeoJson(2002, { phone: '(0800) 6624 5324' })];
+
+        const result = await validateNumbers(Readable.from(elements), 'AT', tmpFilePath);
+
+        expect(result.totalCount).toBe(1);
+        expect(result.invalidCount).toBe(1);
+
+        const invalidItems = JSON.parse(fs.readFileSync(tmpFilePath, 'utf-8'));
+        expect(invalidItems).toHaveLength(1);
+        const invalidItem = invalidItems[0];
+
+        expect(invalidItem.id).toBe(2002);
+        expect(invalidItem.autoFixable).toBe(true);
+        expect(invalidItem.invalidNumbers).toEqual({
+            phone: '(0800) 6624 5324',
+        });
+        expect(invalidItem.suggestedFixes).toEqual({
+            phone: '0800 66245324',
         });
     });
 
@@ -2560,7 +2580,6 @@ describe('validateNumbers', () => {
         const elements = [
             createGeoJson(123456, {
                 fax: FIXABLE_LANDLINE_INPUT,
-                name: 'Faxable',
             }),
         ];
 
@@ -2584,7 +2603,6 @@ describe('validateNumbers', () => {
         const elements = [
             createGeoJson(123456, {
                 fax: VALID_TOLL_FREE,
-                name: 'Toll Free Faxable',
             }),
         ];
 
@@ -2598,7 +2616,6 @@ describe('validateNumbers', () => {
         const elements = [
             createGeoJson(123456, {
                 fax: VALID_MOBILE,
-                name: 'Toll Free Faxable',
             }),
         ];
 
@@ -2613,7 +2630,6 @@ describe('validateNumbers', () => {
             createGeoJson(123456, {
                 phone: FIXABLE_MOBILE_INPUT,
                 fax: FIXABLE_LANDLINE_INPUT,
-                name: 'Faxable',
             }),
         ];
 
@@ -2829,7 +2845,7 @@ describe('isSafeEdit', () => {
 
     test('GB: should return true for a safe edit where for toll free number in international format', () => {
         const originalNumber = '+44 800 00 1234';
-        const newNumber = '0800 001234';
+        const newNumber = '+44 800 001234';
         const countryCode = 'GB';
 
         expect(isSafeEdit(originalNumber, newNumber, countryCode)).toBe(true);
@@ -2852,7 +2868,7 @@ describe('isSafeEdit', () => {
     });
 
     test('CA: should return true for a safe edit with toll free number', () => {
-        // Parsed as a US number by deafult, not possible to differentiate country for toll free numbers
+        // Parsed as a US number by default, not possible to differentiate country for toll free numbers
         const originalNumber = '18888651234';
         const newNumber = '+1-888-865-1234';
         const countryCode = 'CA';


### PR DESCRIPTION
Most countries will be valid if either in valid national or international format. Certain countries force to national format pre requests. Any invalid respects whether it currently looks like national or not