### PR TITLE
support multilingual names

### DIFF
--- a/src/name-utils.js
+++ b/src/name-utils.js
@@ -1,0 +1,30 @@
+// @ts-check
+/**
+ * splits a name like `A;B` or `A / B` or `A (B)`
+ * into the individual components (`['A', 'B']`)
+ * @param {string} name
+ * @returns {string[]}
+ */
+export function splitCompoundName(name) {
+    /** @type {string[]} */
+    const collected = [];
+
+    // first split parentheses
+    let pointer = 0;
+    for (const part of name.matchAll(/\(([^)]+)\)/g)) {
+        collected.push(name.slice(pointer, part.index), part[1]);
+        pointer = part.index + part[0].length;
+    }
+    collected.push(name.slice(pointer));
+
+    // then split other delimiters
+    const parts = collected
+        .flatMap(part => part.split(';'))
+        .flatMap(part => part.split(' / '))
+        .flatMap(part => part.split(' | '))
+        .map(part => part.trim())
+        .filter(Boolean);
+
+    // deduplicate
+    return [...new Set(parts)];
+}

--- a/src/names-processor.js
+++ b/src/names-processor.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { createBaseItem, mapReplacer } from './data-processor.js';
+import { splitCompoundName } from './name-utils.js';
 
 const NAME_LOCALIZED_REGEX = /^name(?::([a-z]{2,3}(?:-[a-zA-Z]{4,})?(?:-[a-zA-Z]{4,})?))$/;
 
@@ -86,6 +87,16 @@ export async function validateNames(elementStream, countryCode, tmpFilePath) {
             });
 
             if (isValidCombo) isInvalid = false;
+
+            if (!(countryCode in BELGIUM_REGION_LANGUAGES)) {
+                // for all other regions, use a generic solution
+                // to check for multilingual names
+                const parts = splitCompoundName(primaryName);
+                const allNames = [...nameTags.values()];
+                if (parts.every(part => allNames.includes(part))) {
+                    isInvalid = false;
+                }
+            }
 
             const noDelimiter = UNDELIMITED_NAME_LANGUAGES[countryCode.split('-')[0]];
             if (primaryName && noDelimiter) {

--- a/test/name-utils.test.js
+++ b/test/name-utils.test.js
@@ -1,0 +1,17 @@
+import { splitCompoundName } from '../src/name-utils';
+
+describe(splitCompoundName, () => {
+    it.each`
+        input                              | output
+        ${''}                              | ${[]}
+        ${'a'}                             | ${['a']}
+        ${'a / b'}                         | ${['a', 'b']}
+        ${'a;b'}                           | ${['a', 'b']}
+        ${'a (b)'}                         | ${['a', 'b']}
+        ${'(a) (b)'}                       | ${['a', 'b']}
+        ${'(a) b'}                         | ${['a', 'b']}
+        ${'a / b (c) d (e / f;g / h) i;j'} | ${['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']}
+    `('$input', ({ input, output }) => {
+        expect(splitCompoundName(input)).toStrictEqual(output);
+    });
+});

--- a/test/names-processor.test.js
+++ b/test/names-processor.test.js
@@ -358,6 +358,37 @@ describe('validateNames', () => {
         expect(result.totalCount).toBe(0);
     });
 
+    describe('valid multilingual names', () => {
+        test.each([
+            { name: 'A / B', 'name:en': 'A', 'name:mi': 'B' },
+            { name: 'A / B', 'name:en': 'B', 'name:mi': 'A' },
+            { name: 'A;B', 'name:en': 'A', 'name:mi': 'B' },
+            { name: 'A (B)', 'name:en': 'A', 'name:mi': 'B' },
+        ])('%s', async tags => {
+            const elements = [createGeoJson(1001, tags)];
+            const result = await validateNames(Readable.from(elements), 'GB', tmpFilePath);
+
+            expect(result.totalCount).toBe(1);
+            expect(result.invalidCount).toBe(0);
+            expect(result.missingNamesCount).toBe(0);
+        });
+    });
+
+    describe('invalid multilingual names', () => {
+        test.each([
+            { name: 'A / B', 'name:en': 'A' },
+            { name: 'A / B', 'name:en': 'B', 'name:mi': 'B' },
+            { name: 'A;B', 'name:en': 'B;A' },
+        ])('%s', async tags => {
+            const elements = [createGeoJson(1001, tags)];
+            const result = await validateNames(Readable.from(elements), 'GB', tmpFilePath);
+
+            expect(result.totalCount).toBe(1);
+            expect(result.invalidCount).toBe(1);
+            expect(result.missingNamesCount).toBe(0);
+        });
+    });
+
     describe('undelimited multilingual names', () => {
         test.each([
             // DZ


### PR DESCRIPTION
follow up from #375

many multilingual communities use a fixed demiter in the `name` tag, such as `/` or `;`. This PR fixes false positives like

```js
{ name: 'A / B', 'name:en': 'A', 'name:mi': 'B' }
```

which are now considered valid