### PR TITLE
fix: use England state code for GB to allow for holiday validation

### DIFF
--- a/src/data/countries.json
+++ b/src/data/countries.json
@@ -1344,7 +1344,7 @@
         }
     },
     "United Kingdom": {
-        "countryCode": "GB",
+        "countryCode": "GB-ENG",
         "locale": "en-GB",
         "safeAutoFixBotEnabled": true,
         "pbfUrl": "https://download.bbbike.org/osm/pbf/region/europe/united-kingdom.osm.pbf",


### PR DESCRIPTION
It gets overriden by other states, so it does not actually apply to the whole of GB