### PR TITLE
fix: never flag whatsapp numbers as foreign

### DIFF
--- a/src/phone-processor.js
+++ b/src/phone-processor.js
@@ -178,7 +178,9 @@ export function processSingleNumber(numberStr, countryCode, osmTags = {}, tag) {
                 getNonStandardCostTypes(countryCode).includes(phoneNumber.getType()) &&
                 phoneNumber.country === 'US';
             foreign =
-                phoneNumber.country.toLowerCase() !== countryCode.toLowerCase() && !isNanpTollFree
+                phoneNumber.country.toLowerCase() !== countryCode.toLowerCase() &&
+                !isNanpTollFree &&
+                tag !== 'contact:whatsapp'
                     ? phoneNumber.country
                     : null;
         } else {

--- a/test/phone-processor/processSingleNumber.test.js
+++ b/test/phone-processor/processSingleNumber.test.js
@@ -821,4 +821,10 @@ describe('processSingleNumber', () => {
         const result = processSingleNumber('+1-800-331-1234 x1', 'US');
         expect(result.isInvalid).toBe(false);
     });
+
+    test("Don't flag a whatsapp number as foreign (common correct tagging)", () => {
+        const result = processSingleNumber('+27 11 555 1234', 'CA', {}, 'contact:whatsapp');
+        expect(result.isInvalid).toBe(false);
+        expect(result.foreign).toBe(null);
+    });
 });


### PR DESCRIPTION
This seems to be common correct tagging